### PR TITLE
Bugfix/o calendar

### DIFF
--- a/src/components/OCalendar/OCalendar.vue
+++ b/src/components/OCalendar/OCalendar.vue
@@ -179,6 +179,7 @@ export default {
         if (!vmodel) {
           this.$emit('update:from', null)
           this.$emit('update:to', null)
+          this.handleDateEmit(vmodel)
           return
         }
         if (vmodel?.date != null && this.advanced) {

--- a/src/components/OCalendar/OCalendar.vue
+++ b/src/components/OCalendar/OCalendar.vue
@@ -179,7 +179,7 @@ export default {
         if (!vmodel) {
           this.$emit('update:from', null)
           this.$emit('update:to', null)
-          this.handleDateEmit(vmodel)
+          this.handleDateEmit()
           return
         }
         if (vmodel?.date != null && this.advanced) {


### PR DESCRIPTION
In case of new value "null" the data wasn't passed to the father component.